### PR TITLE
API: Lens

### DIFF
--- a/transfocate/calculator.py
+++ b/transfocate/calculator.py
@@ -167,10 +167,11 @@ class Calculator(object):
                                 "from target {}.".format(combo.image(z_obj), diff, target_image))
                     #add the difference to the end of image diff
                     image_diff.append(diff)
-            
+                    closest_sols.append(combo)
                 elif use_limits==False:
                     diff=np.abs(combo.image(z_obj)-target_image)
                     image_diff.append(diff)
+                    closes_sols.append(combo)
                 
                 else:
                     logger.debug("Dropping combination that does not meet radius "
@@ -184,7 +185,7 @@ class Calculator(object):
         #order of their coresponding values in image diff
         index=np.argsort(image_diff)
         #make an array out of the combinations list
-        combos = np.asarray(self.combinations)
+        combos = np.asarray(closest_sols)
         #make the sorted list where the lens combos are sorted based on
         #smallest error
         sorted_combos = combos[index]

--- a/transfocate/lens.py
+++ b/transfocate/lens.py
@@ -5,133 +5,83 @@ Basic Lens object handling
 # Standard #
 ############
 import logging
+
 ###############
 # Third Party #
 ###############
-from ophyd import Device, EpicsSignal, EpicsSignalRO
-from ophyd import Component
-from ophyd.utils import set_and_wait
-logger = logging.getLogger(__name__)
+import numpy as np
+import prettytable
+from ophyd import EpicsSignalRO
+from ophyd import FormattedComponent as FC
+from pcdsdevices.inout import InOutRecordPositioner
 
 ##########
 # Module #
 ##########
 
-class Lens(Device):
+logger = logging.getLogger(__name__)
+
+
+class Lens(InOutRecordPositioner):
     """
     Data structure for basic Lens object
     """
-    
-    """
-    Parameters
-    ----------
-    sig_radius : EPICS Read Only signal
-        Radius of beryllium lens measured in microns (um). Affects focus of lens  
-    sig_z : EPICS Read Only signal
-        Lens position along beam pipelin measure in meters (m).
-    sig_focus : EPICS Read Only signal
-        Focal length of lens in meters (m). Is a function of radius
-    state : EPICS Read Only signal
-        Position of the lens.  1 if it is inserted in the beamline and 0 if
-        it is removed
-    in_signal : EPICS signal
-        Signal that triggers EPICS to insert the lens from the beamline
-    out_signal : EPICS signal
-        Signal that triggers EPICS to remove the lens from the beamline
+    _sig_radius = FC(EpicsSignalRO, "{self.prefix_lens}:RADIUS",
+                     auto_monitor=True)
+    _sig_z = FC(EpicsSignalRO, "{self.prefix_lens}:Z",
+                auto_monitor=True)
+    _sig_focus = FC(EpicsSignalRO, "{self.prefix_lens}:FOCUS",
+                    auto_monitor=True)
+    # Default configuration attributes. Read attributes are set correctly by
+    # InOutRecordPositioner
+    _default_configuration_attrs = ['_sig_radius', '_sig_z']
 
-    Note
-    ----
-    The variables radius, z, and focus are now EPICS signals for the lenses.
-    """
-    #defining the EPICS variables (note: these are the signals and not the
-    #values of each variable)
-    sig_radius=Component(EpicsSignalRO, "RADIUS", auto_monitor=True)
-    sig_z = Component(EpicsSignalRO, "Z", auto_monitor=True)
-    sig_focus = Component(EpicsSignalRO, "FOCUS", auto_monitor=True)
-    state = Component(EpicsSignalRO, "STATE") 
-    in_signal = Component(EpicsSignal, "INSERT")
-    out_signal = Component(EpicsSignal, "REMOVE")
+    def __init__(self, prefix, prefix_lens, **kwargs):
+        self.prefix_lens = prefix_lens
+        super().__init__(prefix, **kwargs)
 
-    #z, radius, and focus properties: these convert the EPICS signal into a
-    #value that can be interpreted by the other methods when the property is
-    #called.  Otherwise, the signal itself would be inputted
-    
     @property
     def radius(self):
         """
-        Method converts the EPICS lens radius signal into a float that can be used for
-        calculations.
-        
+        Method converts the EPICS lens radius signal into a float that can be
+        used for calculations.
+
         Returns
         -------
         float
             Returns the radius of the lens
         """
-        return self.sig_radius.value
-    
-    @property 
+        return self._sig_radius.value
+
+    @property
     def z(self):
         """
         Method converts the z position EPICS signal into a float.
-        
+
         Returns
         -------
         float
             Returns the z position of the lens in meters along the beamline
         """
-        return self.sig_z.value
-    
+        return self._sig_z.value
+
     @property
     def focus(self):
         """
         Method converts the EPICS focal length signal of the lens into a float
-        
+
         Returns
         -------
         float
-            Returns the focal length of the lens in meters 
+            Returns the focal length of the lens in meters
         """
-        return self.sig_focus.value
-
-    @property
-    def inserted(self):
-        """
-        Method checks if the lens is inserted in the beam pipeline or not
-
-        Returns
-        -------
-        int
-            Returns 1 if the lens in inserted in the beam pipeline and 0 if it
-            has been removed.
-
-        """
-        #checks if the state value is 1 (inserted) or 0 (removed)
-        if self.state.value==1:
-            return True
-        else:
-            return False
-
-    def insert(self):
-        """
-        Method sets the EPICS insert signal to 1 which triggers the motor to
-        insert the lens from the beam pipeline
-        """
-        #Changes in_signal to 1 which causes the lense to be inserted
-        self.in_signal.put(1)
-    
-    def remove(self):
-        """
-        Method sets the EPICS remove signal to 1 which triggers the motor to
-        remove the lens from the beam pipeline
-        """
-        #changes out_signal to 1 which causes the lense to be removed
-        self.out_signal.put(1)
+        return self._sig_focus.value
 
     def image_from_obj(self, z_obj):
         """
-        Method calculates the image distance in meters along the beam
-        pipeline from a point of origin given the focal length of the lens, location of lens, and location of
-        object.
+        Method calculates the image distance in meters along the beam pipeline
+        from a point of origin given the focal length of the lens, location of
+        lens, and location of object.
 
         Parameters
         ----------
@@ -140,7 +90,7 @@ class Lens(Device):
 
         Returns
         -------
-        float
+        image
             Returns the distance z_im of the image along the beam pipeline from
             a point of origin in meters (m)
         Note
@@ -148,44 +98,33 @@ class Lens(Device):
         If the location of the object (z_obj) is equal to the focal length of
         the lens, this function will return infinity.
         """
-        #check if the lens object is at the focal length.  
-        #If this happens, then the image location will be infinity.
-        #Note, this should not effect the recursive calculations that occur
-        #later in the code
-        if z_obj==self.focus:
+        # Check if the lens object is at the focal length
+        # If this happens, then the image location will be infinity.
+        # Note, this should not effect the recursive calculations that occur
+        # later in the code
+        if z_obj == self.focus:
             return np.inf
-        #find the object location for the lens
-        o=self.z-z_obj
-        #calculate the inverse of i from the thin lens equation
-        i_inv=(1/self.focus)-(1/o)
-        #take the inverse of 1/i to get i
-        i=1/i_inv
-        #add the imsge to the lens z location aling the beam pipeline to get
-        #the z position of the image
-        z_im=i+self.z
-
-        logger.debug("object measurement: %s i_invers: %s i: %s z image:%s"%(o, i_inv, i, z_im))
-        
-        return z_im
+        # Find the object location for the lens
+        obj = self.z - z_obj
+        # Calculate the location of the focal plane
+        plane = 1/(1/self.focus - 1/obj)
+        # Find the position in accelerator coordinates
+        return plane + self.z
 
 
-class LensConnect(Device):
+class LensConnect:
     """
     Data structure for a basic system of lenses
     """
-    #define the variables for lensconnect class
-    #the lenses list can be a list of arbitrary length
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args):
         """
         Parameters
         ----------
-        *args
-            Variable length argument list of the lenses in the system, their radii,
-            z position, and focal length.
-        **kwargs
-            Arbitraty keyword argumens.
+        args
+            Variable length argument list of the lenses in the system, their
+            radii, z position, and focal length.
         """
-        self.lenses=args
+        self.lenses = sorted(args, key=lambda lens: lens.z)
 
     @property
     def effective_radius(self):
@@ -197,70 +136,33 @@ class LensConnect(Device):
         float
             returns the effective radius of the lens array.
         """
-        if not self.lenses or len(self.lenses)==0:
-            return 0 #this method is only used if we impliment the option of No xrt/tfs lenses
-
-        else:
-            #set a collect variable to add the radii to
-            collect=0
-            #loop through the lenses in the array and add 1/radius to the
-            #collect variable
-            for lens in self.lenses:
-                collect+=(1/lens.radius)
-            logger.debug("lens radius: %s length of lens list: %s collect variable %s"%(lens.radius, len(self.lenses), collect)) 
-            #take the inverse of collect to get the effective radius of the
-            #lens array
-            return 1/collect
+        if not self.lenses:
+            return 0.0
+        return 1/np.sum(np.reciprocal([float(l.radius) for l in self.lenses]))
 
     def image(self, z_obj):
         """
-        Method recursively calculates the z location of the image of a system of
-        lenses and returns it in meters (m)
-    
+        Method recursively calculates the z location of the image of a system
+        of lenses and returns it in meters (m)
+
         Parameters
         ----------
         z_obj
-            Location of the object along the beam pipline from a designated point
-            of origin in meters (m)
-        
+            Location of the object along the beam pipline from a designated
+            point of origin in meters (m)
+
         Returns
         -------
         float
             returns the location z of a system of lenses in meters (m).
         """
-        #set the initial image as the z object
-        image=z_obj
-        #call z_based_sort to put the lenses in order from closest to furthest
-        #to the reference point on the beamline
-        #save this sorted array into a list
-        lens_list=self.z_based_sort
-        #loop through the list and recursively calculate the image of the lens
-        #array
-        for lens in lens_list:
-            image=lens.image_from_obj(image)
-            logger.debug("image: %s" %(image))
+        # Set the initial image as the z object
+        image = z_obj
+        # Determine the final output by looping through lenses
+        for lens in self.lenses:
+            image = lens.image_from_obj(image)
         return image
 
-    @property
-    def z_based_sort(self):
-        """
-        Method sorts the array of lenses into a new list based on their z
-        position along the beamline.  Lenses are sorted in ascending order.
-
-        Returns
-        -------
-        list
-            Returns the sorted list of lenses 
-        """
-        #define variable to count the number of lenses
-        count=0
-        #sort the lenses based on their z position
-        sorted_lenses=sorted(self.lenses, key=lambda lens: lens.z)
-        for lens in sorted_lenses:
-            count +=1
-            logger.debug("z position for lens number %s is %s" %(count,lens.z))
-        return sorted_lenses
-    
     @property
     def nlens(self):
         """
@@ -271,27 +173,23 @@ class LensConnect(Device):
         int
             Returns the total number of lenses in the array.
         """
-        logger.debug("number of lenses in list: %s" %(len(self.lenses)))
-        #find the length of the list of lenses
         return len(self.lenses)
-    
+
+    def _info(self):
+        """
+        Create a table with lens information
+        """
+        # Create initial table
+        pt = prettytable.PrettyTable(['Prefix', 'Radius', 'Z'])
+        # Adjust table settings
+        pt.align = 'l'
+        pt.float_format = '8.5'
+        for lens in self.lenses:
+            pt.add_row([lens.prefix, lens.radius, lens.z])
+        return pt
+
     def show_info(self):
         """
-        Method prints the information for each lens in the LensConnect. Listed
-        information includes: name, radius, and, z position
+        Show a table of information on the lens
         """
-        for lens in self.lenses:
-            logging.info("name: %s radius: %s z-value: %s"%(lens.name, lens.radius, lens.z))
-            print("name: %s radius: %s z-value: %s"%(lens.name, lens.radius, lens.z))
-
-    def apply_lenses(self):
-        """
-        Method inserts the lenses in a LensConnect into the transfocator by
-        setting the individual lens' insert EPICS signals to 1 which triggers
-        them to be inserted into the beamline
-        """
-        #loop through lenses in the LensConnect
-        for lens in self.lenses:
-            #insert the lenses into the transfocator
-            lens.insert()
-            #logger.info("in signal value is %s"%(lens.in_signal.value))
+        print(self._info())

--- a/transfocate/lens.py
+++ b/transfocate/lens.py
@@ -25,6 +25,14 @@ logger = logging.getLogger(__name__)
 class Lens(InOutRecordPositioner):
     """
     Data structure for basic Lens object
+
+    Parameters
+    ----------
+    prefix : str
+        Name of the state record that controls the PV
+
+    prefix_lens : str
+        Prefix for the PVs that contain focusing information
     """
     _sig_radius = FC(EpicsSignalRO, "{self.prefix_lens}:RADIUS",
                      auto_monitor=True)
@@ -115,6 +123,11 @@ class Lens(InOutRecordPositioner):
 class LensConnect:
     """
     Data structure for a basic system of lenses
+
+    Parameters
+    ----------
+    args : Lens
+        Lens objects
     """
     def __init__(self, *args):
         """

--- a/transfocate/tests/conftest.py
+++ b/transfocate/tests/conftest.py
@@ -68,10 +68,10 @@ class FakeLens(object):
 @pytest.fixture(scope='module')
 @using_fake_epics_pv
 def lens():
-    l =  Lens("TST:TFS:LENS:01:", name='Lens')
-    l.sig_radius._read_pv.put(500.0)
-    l.sig_z._read_pv.put(100.0)
-    l.sig_focus._read_pv.put(50.0)
+    l =  Lens("TST:TFS:LENS:01:", 'TST:XFLS:01', name='Lens')
+    l._sig_radius._read_pv.put(500.0)
+    l._sig_z._read_pv.put(100.0)
+    l._sig_focus._read_pv.put(50.0)
     return l
 
 @pytest.fixture(scope='module')

--- a/transfocate/tests/test_lens.py
+++ b/transfocate/tests/test_lens.py
@@ -31,9 +31,9 @@ def test_image_from_obj(lens):
 @using_fake_epics_pv
 def test_lens_motion(lens):
     lens.insert()
-    assert lens.in_signal.value == 1
+    assert lens.state._write_pv.get() == 'IN'
     lens.remove()
-    assert lens.out_signal.value == 1
+    assert lens.state._write_pv.get() == 'OUT'
 
 def test_lens_connect_effective_radius(array):
     assert np.isclose(array.effective_radius, 250, atol=0.1)
@@ -46,3 +46,6 @@ def test_lens_connect_image(array):
 
 def test_number_of_lenses(array):
     assert array.nlens== 2
+
+def test_lens_sorting(array):
+    assert array.lenses[0].z < array.lenses[1].z

--- a/transfocate/transfocator.py
+++ b/transfocate/transfocator.py
@@ -134,17 +134,17 @@ class Transfocator(Device):
         #find the best combination of lenses to match the target image
         best_combo = self.find_best_combo(i, n, obj)
         
-        #insert the lenses in the best combo LensConnect
-        best_combo.apply_lenses()
-        
         #loop through all the lenses and, if they are not in best_combo, remove
         #them.  If they are already removed, this should not affect them
         for lens in self.xrt_lenses:
             if lens not in best_combo.lenses:
                 lens.remove()
-        
+            else:
+                lens.insert()
         for lens in self.tfs_lenses:
             if lens not in best_combo.lenses:
                 lens.remove()
+            else:
+                lens.insert()
         
         


### PR DESCRIPTION
## Details
The first of wave of cleanup for this module. 

### API
* You now need to pass two prefixes into the `Lens` class. One is for the calculation information `.z`, `.radius`, the other is for the state information.

### Enhancements
* `show_info` is a prettytable. 
* Implemented as an `InOutRecordPositioner`


### Deprecations
* Deprecated `z_based_sort` we don't need to continually sort. Do this once on `__init__` and store the results. Assume that we won't have people manually appending `Lens` objects places
* Deprecate `apply`. This was always a partial implementation. It is great to insert the lenses you know need to be inserted, but not super helpful if you don't remove lenses that are not. That means this needs to be handled by the complete Transfocator class.

### Fixes
* Fixes a critical bug in the `find_best_combo`. The function restricts which combinations of lenses we actually calculate, but before this fix, the sort was applied to the full array of combinations. 

### Style
* Lens file passes flake8. Other files will be done when they are processed with a finer tooth comb.

## Motivation 
Closes #7 

## Tests
* Testing logic was touched minimally. 