### PR TITLE
API: Calculator

### DIFF
--- a/transfocate/__init__.py
+++ b/transfocate/__init__.py
@@ -1,7 +1,7 @@
 import logging
 
 from .lens import Lens, LensConnect
-from .calculator import TransfocatorCombo, Calculator
+from .calculator import Calculator
 from .transfocator import Transfocator
 
 logger = logging.getLogger(__name__)

--- a/transfocate/calculator.py
+++ b/transfocate/calculator.py
@@ -9,39 +9,10 @@ from transfocate.lens import LensConnect
 
 logger = logging.getLogger(__name__)
 
-class TransfocatorCombo(object):
-    """Class creates and keeps track of the lens array lists and calculates the
-    image of the combined xrt/tfs beryllium lens array
 
-    Attributes
-    ----------
-    xrt : list
-        A list of the xrt lenses with all the attributes of the LensConnect
-        class
-    tfs : list
-        A list of the tfs lenses with all the attributes of the LensConnect
-        class
+class Calculator:
     """
-    #define TransfocatorCombo attributes
-    #Note: onely one xrt can be entered for this but multiple tfs lenses can be
-    #entered
-    def __init__(self, xrt, tfs):
-        self.xrt=LensConnect(xrt)
-        self.tfs=LensConnect(*tfs)
-
-    def image(self, z_obj):
-        """Method calculates the image of the combined tfs and xrt lens array
-        
-        Returns
-        -------
-        float
-            Returns the image of the xrt/tfs lens array
-        """
-        #
-        xrt_image=self.xrt.image(z_obj)
-        total_image=self.tfs.image(xrt_image)
-        logger.debug("the xrt image of the array is %s and the image of the combined xrt/tfs array is %s" %(xrt_image,total_image))
-        return total_image
+    Class for the transfocator beryllium lens calculator.
 
 
 class Calculator(object):

--- a/transfocate/calculator.py
+++ b/transfocate/calculator.py
@@ -14,44 +14,19 @@ class Calculator:
     """
     Class for the transfocator beryllium lens calculator.
 
-
-class Calculator(object):
-    """Class for the transfocator beryllium lens calculator.
-
-    Attributes
+    Parameters
     ----------
     xrt_lenses : list
         A list of the xrt prefocus lenses
+
     tfs_lenses : list
-        A list of the beryllium transfocator lenses
-    xrt_limit : float 
-        The hard limit i.e. minimum effective radius that the xrt lens array can safely
-        have
-    tfs : float
-        The hard limit i.e. maximum effective radius that tfs lense array can
-        safely have
+        A list of the transfocator lenses
     """
-    #Define calculator variables
-    #There are not xtr or tfs limits unless they are set by the signals
-    def __init__(self, xrt_lenses, tfs_lenses, xrt_limit=None, tfs_limit=None):
-        self.xrt_lenses=xrt_lenses
-        self.tfs_lenses=tfs_lenses
-        self.xrt_limit=xrt_limit
-        self.tfs_limit=tfs_limit
+    def __init__(self, xrt_lenses, tfs_lenses):
+        self.xrt_lenses = xrt_lenses
+        self.tfs_lenses = tfs_lenses
 
-    @property
-    def combinations(self):
-        #Note: all lens arrays will consist of one prefocus lens and an array
-        #of tfs lenses
-        
-        """Method calculates and returns all possible combinations of the xrt
-        and tfs lense arrays
-
-        Returns
-        -------
-        list
-            Returns a list of all possible combinations of the xrt and tfs
-            lense arrays
+    def combinations(self, include_prefocus=True):
         """
         
         #create empty lists for all possible xrt and tfs combos and all possible tfs combos

--- a/transfocate/config.py
+++ b/transfocate/config.py
@@ -1,7 +1,6 @@
 from transfocate.lens import Lens
 from transfocate.lens import LensConnect
 from transfocate.calculator import Calculator
-from transfocate.calculator import TransfocatorCombo
 from transfocate.transfocator import Transfocator
 
 prefocus=[Lens("MFX:LENS:DIA:01:"), 

--- a/transfocate/lens.py
+++ b/transfocate/lens.py
@@ -206,3 +206,10 @@ class LensConnect:
         Show a table of information on the lens
         """
         print(self._info())
+
+    @classmethod
+    def connect(cls, array1, array2):
+        """
+        Create a new LensConnect from the combination of multiple
+        """
+        return cls(*array1.lenses, *array2.lenses)

--- a/transfocate/tests/conftest.py
+++ b/transfocate/tests/conftest.py
@@ -100,6 +100,4 @@ def calculator():
            FakeLens(500., 280., 55.)]
     #Define Calculator
     return Calculator(xrt_lenses = prefocus,
-                      tfs_lenses = tfs,
-                      xrt_limit  = 400,
-                      tfs_limit  = 750)
+                      tfs_lenses = tfs)

--- a/transfocate/tests/test_calculator.py
+++ b/transfocate/tests/test_calculator.py
@@ -12,7 +12,6 @@ import numpy as np
 ##########
 from .conftest import FakeLens
 from transfocate.lens       import Lens
-from transfocate.calculator import TransfocatorCombo
 
 
 def test_calculator_combinations(calculator):
@@ -24,12 +23,3 @@ def test_calculator_find_combinations(calculator):
     solutions = calculator.find_combinations(312.5)
     #Assert we found the accurate combination
     assert np.isclose(solutions[0].image(0.0), 312.5, atol=0.1)
-
-def test_transfocator_combo():
-    #Define xrt and tfs lists
-    xrt=FakeLens(300.0, 100., 25.)
-    tfs=[FakeLens(500., 275., 25.),
-         FakeLens(500., 280., 55.)]
-    #Define TransfocatorCombo
-    test_combo=TransfocatorCombo(xrt, tfs)
-    assert np.isclose(test_combo.image(200.0), 297.18, atol=0.1)

--- a/transfocate/tests/test_calculator.py
+++ b/transfocate/tests/test_calculator.py
@@ -10,16 +10,14 @@ import numpy as np
 ##########
 # Module #
 ##########
-from .conftest import FakeLens
-from transfocate.lens       import Lens
-
 
 def test_calculator_combinations(calculator):
-    #Eight possible transfocator combinations
-    #Three possible prefocus lens choices
-    assert len(calculator.combinations) == 8
+    # Three possible transfocator combinations
+    # Two possible prefocus lens choices
+    assert len(calculator.combinations()) == 6
+    assert len(calculator.combinations(include_prefocus=False)) == 3
 
 def test_calculator_find_combinations(calculator):
-    solutions = calculator.find_combinations(312.5)
-    #Assert we found the accurate combination
-    assert np.isclose(solutions[0].image(0.0), 312.5, atol=0.1)
+    solution = calculator.find_solution(312.5)
+    # Assert we found the accurate combination
+    assert np.isclose(solution.image(0.0), 312.5, atol=0.1)

--- a/transfocate/tests/test_transfocate.py
+++ b/transfocate/tests/test_transfocate.py
@@ -97,9 +97,9 @@ def test_transfocator_find_best_combo(transfocator):
     assert np.isclose(305.35, transfocator.find_best_combo(305.35).image(0.0), atol=0.1)
 
     #test xrt[1] and tfs[0,1,2,3]
-    assert transfocator.find_best_combo(356.48).nlens==5
-    assert np.isclose(69.76, transfocator.find_best_combo(356.48).effective_radius, atol=0.1)
-    assert np.isclose(356.48, transfocator.find_best_combo(356.48).image(0.0), atol=0.1)
+    assert transfocator.find_best_combo(356.48, n=5).nlens==5
+    assert np.isclose(69.76, transfocator.find_best_combo(356.48, n=5).effective_radius, atol=0.1)
+    assert np.isclose(356.48, transfocator.find_best_combo(356.48, n=5).image(0.0), atol=0.1)
 
 def test_transfocator_focus_at(transfocator):
     #test with tfs[0] and xrt[0]
@@ -123,7 +123,7 @@ def test_transfocator_focus_at(transfocator):
     assert [lens.inserted for lens in transfocator.tfs_lenses] == [True, False, False, False]
     
     #test xrt[1] and tfs[0,1,2,3]
-    transfocator.focus_at(356.48)
+    transfocator.focus_at(356.48, n=5)
     assert [lens.inserted for lens in transfocator.xrt_lenses] == [False, True]
     assert [lens.inserted for lens in transfocator.tfs_lenses] == [True, True, True, True]
 

--- a/transfocate/transfocator.py
+++ b/transfocate/transfocator.py
@@ -4,7 +4,6 @@ import numpy as np
 from transfocate.lens import Lens
 from transfocate.lens import LensConnect
 from transfocate.calculator import Calculator
-from transfocate.calculator import TransfocatorCombo
 import logging 
 from ophyd import Device, EpicsSignal, EpicsSignalRO
 from ophyd import Component

--- a/transfocate/transfocator.py
+++ b/transfocate/transfocator.py
@@ -95,22 +95,10 @@ class Transfocator(Device):
             meters.  Parameter will be set to 0 unles otherwise specified by
             the user
         """
-       
-        #create a calculator 
-        calc=Calculator(self.xrt_lenses, self.tfs_lenses, self.xrt_limit.value, self.tfs_limit.value)
-        #create a list of all the possible combinations of the lenses in the
-        #calculator and puts them in order with the array with the image
-        #closest to the target image first and so on
-        combos=calc.find_combinations(i, n, obj)
-        
-        #create a list for the best combination of lenses
-        best_combo=[]
-        #extend the list to add the xrt and tfs lenses as Lenses
-        best_combo.extend(combos[0].xrt.lenses)
-        best_combo.extend(combos[0].tfs.lenses)
-        #instantiate the best combo as a LensConnect objet
-        best_combo=LensConnect(*best_combo)
-        return best_combo
+        # Create a calculator 
+        calc = Calculator(self.xrt_lenses, self.tfs_lenses)
+        # Return the solution
+        return calc.find_solution(i, n, obj)
 
     def focus_at(self, i, n=4, obj=0.0):
         """Method inserts the lenses in this array into the beam pipeline.


### PR DESCRIPTION
## Details

### API
* `combinations` is now callable. In certain cases, operators may not want to prefocus with XRT lenses. This function is now callable with an `include_prefocus` option
* `find_combinations` is now `find_solution`. At first conception, it was thought that operators might want multiple solutions to try when requesting a focal plane. In practice, the best returned solution has been the best answer. In the future what this method really needs is keywords to force certain lenses in or out. i.e  don't include prefocusing lens 2. 

### Deprecations
* `TransfocatorCombo` was an unwieldy object and largely unnecessary. This was completely factored out.

### Maintenance
* Prefocusing should be included in the `nlens` count.
* We no longer care about the limits when requesting combinations. A bit of backstory,  when this module was first written it took a long time for the correct solution to be found. A quick speed-up we thought of was to only include combinations that passed the interlock. Afterwards, it was discovered that the EPICS calls were being very inefficiently and now the entire parameter space can be iterated through very quickly. In practice, the calculator will never suggest a lens combination that is unsafe unless the user requests an unsafe location to focus.