### PR TITLE
DEV: Save logs to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+logs/
 
 # Translations
 *.mo

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python
+import os
 import sys
+import logging
+from pathlib import Path
+from logging.handlers import RotatingFileHandler
+
 import pytest
 
 if __name__ == '__main__':
@@ -11,6 +16,36 @@ if __name__ == '__main__':
     if len(sys.argv) >1:
         args.extend(sys.argv[1:])
 
-    print('pytest arguments: {}'.format(args))
+    txt = 'pytest arguments: {}'.format(args)
+    print(txt)
+
+    # Setup logger and log everything to a file
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+    log_dir = Path(os.path.dirname(__file__)) / 'logs'
+    log_file = log_dir / 'run_tests_log.txt'
+
+    if not log_dir.exists():
+        log_dir.mkdir(parents=True)
+    if log_file.exists():
+        do_rollover = True
+    else:
+        do_rollover = False
+
+    handler = RotatingFileHandler(str(log_file), backupCount=5,
+                                  encoding=None, delay=0)
+    if do_rollover:
+        handler.doRollover()
+    formatter = logging.Formatter(fmt=('%(asctime)s.%(msecs)03d '
+                                       '%(module)-15s '
+                                       '%(levelname)-8s '
+                                       '%(threadName)-10s '
+                                       '%(message)s'),
+                                  datefmt='%H:%M:%S')
+    handler.setFormatter(formatter)
+    root_logger.addHandler(handler)
+
+    logger = logging.getLogger(__name__)
+    logger.info(txt)
 
     sys.exit(pytest.main(args))

--- a/transfocate/tests/conftest.py
+++ b/transfocate/tests/conftest.py
@@ -2,7 +2,6 @@
 # Standard #
 ############
 import os
-import logging
 import subprocess
 from collections import namedtuple
 ###############
@@ -16,30 +15,6 @@ from transfocate.lens import Lens, LensConnect
 from transfocate.calculator import Calculator
 from pcdsdevices.sim.pv import using_fake_epics_pv
 
-
-#################
-# Logging Setup #
-#################
-#Enable the logging level to be set from the command line
-def pytest_addoption(parser):
-    parser.addoption("--log", action="store", default="INFO",
-                     help="Set the level of the log")
-    parser.addoption("--logfile", action="store", default=None,
-                     help="Write the log output to specified file path")
-
-#Create a fixture to automatically instantiate logging setup
-@pytest.fixture(scope='session', autouse=True)
-def set_level(pytestconfig):
-    #Read user input logging level
-    log_level = getattr(logging, pytestconfig.getoption('--log'), None)
-
-    #Report invalid logging level
-    if not isinstance(log_level, int):
-        raise ValueError("Invalid log level : {}".format(log_level))
-
-    #Create basic configuration
-    logging.basicConfig(level=log_level,
-                        filename=pytestconfig.getoption('--logfile'))
 
 ################
 # Mock Classes #


### PR DESCRIPTION
Logging system wasn't very effective. The CLI arguments no longer worked after the tests were moved into the repository itself. Moved to a system where logs are saved to disk to be inspected lated.

Closes #2 