### PR TITLE
API: Single prefix for Lens

### DIFF
--- a/transfocate/tests/conftest.py
+++ b/transfocate/tests/conftest.py
@@ -43,7 +43,7 @@ class FakeLens(object):
 @pytest.fixture(scope='module')
 @using_fake_epics_pv
 def lens():
-    l =  Lens("TST:TFS:LENS:01:", 'TST:XFLS:01', name='Lens')
+    l =  Lens("TST:TFS:LENS:01:", name='Lens')
     l._sig_radius._read_pv.put(500.0)
     l._sig_z._read_pv.put(100.0)
     l._sig_focus._read_pv.put(50.0)

--- a/transfocate/tests/test_lens.py
+++ b/transfocate/tests/test_lens.py
@@ -41,9 +41,9 @@ def test_lens_state(lens):
 @using_fake_epics_pv
 def test_lens_motion(lens):
     lens.insert()
-    assert lens.state._write_pv.get() == 'IN'
+    lens._insert._write_pv.get() == 1
     lens.remove()
-    assert lens.state._write_pv.get() == 'OUT'
+    lens._remove._write_pv.get() == 1
 
 def test_lens_connect_effective_radius(array):
     assert np.isclose(array.effective_radius, 250, atol=0.1)

--- a/transfocate/tests/test_lens.py
+++ b/transfocate/tests/test_lens.py
@@ -26,11 +26,20 @@ def test_image_from_obj(lens):
     assert np.isclose(lens.image_from_obj(75.0), 50.0, atol=0.1)
 
 @using_fake_epics_pv
-def test_lens_motion(lens):
-    lens.state._read_pv.put(0)
-    assert lens.inserted == False
-    lens.state._read_pv.put(1)
+def test_lens_state(lens):
+    # Inserted Lens
+    lens._removed._read_pv.put(0)
+    lens._inserted._read_pv.put(1)
     assert lens.inserted == True
+    assert lens.removed == False
+    # Removed Lens
+    lens._removed._read_pv.put(1)
+    lens._inserted._read_pv.put(0)
+    assert lens.removed == True
+    assert lens.inserted == False
+
+@using_fake_epics_pv
+def test_lens_motion(lens):
     lens.insert()
     assert lens.state._write_pv.get() == 'IN'
     lens.remove()

--- a/transfocate/tests/test_lens.py
+++ b/transfocate/tests/test_lens.py
@@ -12,31 +12,35 @@ import numpy as np
 ##########
 from pcdsdevices.sim.pv import using_fake_epics_pv
 
+
 @using_fake_epics_pv
 def test_lens_properties(lens):
     assert np.isclose(500.0, lens.radius, atol=0.1)
     assert np.isclose(100.0, lens.z,      atol=0.1)
     assert np.isclose(50.0,  lens.focus,  atol=0.1)
 
+
 @using_fake_epics_pv
 def test_image_from_obj(lens):
-    #Real image
+    # Real image
     assert np.isclose(lens.image_from_obj(0.0),  200.0, atol=0.1)
-    #Imaginary image
+    # Imaginary image
     assert np.isclose(lens.image_from_obj(75.0), 50.0, atol=0.1)
+
 
 @using_fake_epics_pv
 def test_lens_state(lens):
     # Inserted Lens
     lens._removed._read_pv.put(0)
     lens._inserted._read_pv.put(1)
-    assert lens.inserted == True
-    assert lens.removed == False
+    assert lens.inserted
+    assert not lens.removed
     # Removed Lens
     lens._removed._read_pv.put(1)
     lens._inserted._read_pv.put(0)
-    assert lens.removed == True
-    assert lens.inserted == False
+    assert lens.removed
+    assert not lens.inserted
+
 
 @using_fake_epics_pv
 def test_lens_motion(lens):
@@ -45,8 +49,10 @@ def test_lens_motion(lens):
     lens.remove()
     lens._remove._write_pv.get() == 1
 
+
 def test_lens_connect_effective_radius(array):
     assert np.isclose(array.effective_radius, 250, atol=0.1)
+
 
 def test_lens_connect_image(array):
     assert np.isclose(array.image(0.0),  312.5,   atol=0.1)
@@ -54,8 +60,10 @@ def test_lens_connect_image(array):
     assert np.isclose(array.image(80.0), 303.409, atol=0.1)
     assert np.isclose(array.image(125.0), 304.6875, atol=0.1)
 
+
 def test_number_of_lenses(array):
-    assert array.nlens== 2
+    assert array.nlens == 2
+
 
 def test_lens_sorting(array):
     assert array.lenses[0].z < array.lenses[1].z

--- a/transfocate/tests/test_lens.py
+++ b/transfocate/tests/test_lens.py
@@ -45,9 +45,11 @@ def test_lens_state(lens):
 @using_fake_epics_pv
 def test_lens_motion(lens):
     lens.insert()
-    lens._insert._write_pv.get() == 1
+    assert lens._insert._write_pv.get() == 1
+    lens._removed._read_pv.put(0)
+    lens._inserted._read_pv.put(1)
     lens.remove()
-    lens._remove._write_pv.get() == 1
+    assert lens._remove._write_pv.get() == 1
 
 
 def test_lens_connect_effective_radius(array):

--- a/transfocate/tests/test_lens.py
+++ b/transfocate/tests/test_lens.py
@@ -23,13 +23,14 @@ def test_image_from_obj(lens):
     #Real image
     assert np.isclose(lens.image_from_obj(0.0),  200.0, atol=0.1)
     #Imaginary image
+    assert np.isclose(lens.image_from_obj(75.0), 50.0, atol=0.1)
+
+@using_fake_epics_pv
+def test_lens_motion(lens):
     lens.state._read_pv.put(0)
     assert lens.inserted == False
     lens.state._read_pv.put(1)
     assert lens.inserted == True
-
-@using_fake_epics_pv
-def test_lens_motion(lens):
     lens.insert()
     assert lens.state._write_pv.get() == 'IN'
     lens.remove()


### PR DESCRIPTION
## Description
Reverting a design choice made in #14. At first I thought the cleaner implementation would be to pass two prefixes to `Lens` one for the focusing information, one for motion. At second thought, we can make a `InOutPVStatePositioner` that will accept one prefix. 

**Trade off:** Slightly more cryptic code. Far easier for users.