### PR TITLE
MAINT: IMS instead of EpicsMotor

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - python {{PY_VER}}*,>=3.6
     - ophyd
     - numpy
-    - pcdsdevices
+    - pcdsdevices >=0.5.0
 
 test:
   imports:

--- a/transfocate/transfocator.py
+++ b/transfocate/transfocator.py
@@ -1,7 +1,7 @@
 import math
 import logging
 
-from pcdsdevices.device_types import EpicsMotor
+from pcdsdevices.device_types import IMS
 from ophyd import Device, EpicsSignalRO, Component, FormattedComponent
 from ophyd.status import wait as status_wait
 
@@ -37,7 +37,7 @@ class Transfocator(Device):
     tfs_10 = Component(Lens, ":TFS:10")
 
     # Translation
-    translation = FormattedComponent(EpicsMotor, "MFX:TFS:MMS:21")
+    translation = FormattedComponent(IMS, "MFX:TFS:MMS:21")
 
     def __init__(self, prefix, *, nominal_sample=399.88103, **kwargs):
         self.nominal_sample = nominal_sample


### PR DESCRIPTION
## Details
We now have a more specific class to handle the intricacies of both the PCDS Motor Record and the IMS controller itself. This should be used instead of the `ophyd.EpicsMotor` which is incompatible with our IMS motors.  Also specified a minimum version number of `pcdsdevices` when the special `IMS` class first appeared.