### PR TITLE
CI: Install ophyd from conda-forge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ install:
   - conda install conda-build anaconda-client
   - conda update -q conda
   - conda config --append channels pcds-tag
-  - conda config --append channels lightsource2-tag
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a


### PR DESCRIPTION
## Description
We were installing `ophyd` from `lightsource2-tag` where we were picking up the development builds. This removes the channel entirely. This is more inline with how the package will be used in the wild and therefore I believe is the correct choice.

This was motivated by the following issue https://github.com/pcdshub/transfocate/issues/27