### PR TITLE
MAINT: No valid solution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
   - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda build -q conda-recipe --output-folder bld-dir
+  - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
   - conda config --add channels "file://`pwd`/bld-dir"
   # Create test environment
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION transfocate --file dev-requirements.txt

--- a/transfocate/transfocator.py
+++ b/transfocate/transfocator.py
@@ -112,7 +112,10 @@ class Transfocator(Device):
         calc = Calculator(allowed_xrt, self.tfs_lenses)
         # Return the solution
         combo = calc.find_solution(target, **kwargs)
-        combo.show_info()
+        if combo:
+            combo.show_info()
+        else:
+            logger.error("Unable to find a valid solution for target")
         return combo
 
     def set(self, value, **kwargs):


### PR DESCRIPTION
## Description
If the Transfocator IOC is not configured correctly we will not get a `None` back from the Transfocator Calculator. The high level user interface should catch this and just give an error message instead of using calling `combo.show_info` which just raises a different exception masking the root problem.

Also had to adjust the Travis configuration now that `Miniconda` will install `3.7`.

## Motivation
Closes #30 