### PR TITLE
ENH: Input requested energy

### DIFF
--- a/transfocate/calculator.py
+++ b/transfocate/calculator.py
@@ -67,7 +67,7 @@ class Calculator:
         return combos
 
     def find_solution(self, target, n=4, z_obj=0.0,
-                      include_prefocus=True):
+                      include_prefocus=True, requested=False):
         """
         Find a combination to reach a specific focus
 
@@ -88,6 +88,9 @@ class Calculator:
             Use only combinations that include a prefocusing lens. If False,
             only combinations of Transfocator lenses are returned
 
+        requested: bool, optional
+            Use requested energy (and therefore requested focus).
+
         Returns
         -------
         array: LensConnect
@@ -101,7 +104,7 @@ class Calculator:
             # Check to see if the number of lenses is less than the limit
             if combo.nlens <= n:
                 try:
-                    image = combo.image(z_obj)
+                    image = combo.image(z_obj, requested=requested)
                     diff = np.abs(image - target)
                 except Exception as exc:
                     logger.exception("Unable to calculate image position")

--- a/transfocate/lens.py
+++ b/transfocate/lens.py
@@ -87,7 +87,20 @@ class Lens(InOutPVStatePositioner):
         """
         return self._sig_focus.value
 
-    def image_from_obj(self, z_obj):
+    @property
+    def req_focus(self):
+        """
+        Method converts the EPICS requested focal length signal of the lens into
+        a float
+
+        Returns
+        -------
+        float
+            Returns the focal length of the lens in meters
+        """ 
+        return self._req_focus.value
+
+    def image_from_obj(self, z_obj, requested=False):
         """
         Method calculates the image distance in meters along the beam pipeline
         from a point of origin given the focal length of the lens, location of
@@ -97,6 +110,10 @@ class Lens(InOutPVStatePositioner):
         ----------
         z_obj
             Location of object along the beamline in meters (m)
+
+        requested
+            Bool to select requested or current beam energy (and as a result
+            requested or current lens focus)
 
         Returns
         -------
@@ -114,12 +131,18 @@ class Lens(InOutPVStatePositioner):
         # If this happens, then the image location will be infinity.
         # Note, this should not effect the recursive calculations that occur
         # later in the code
-        if obj == self.focus:
-            return np.inf
-        # Calculate the location of the focal plane
-        plane = 1/(1/self.focus - 1/obj)
-        # Find the position in accelerator coordinates
-        return plane + self.z
+        if not requested:
+            if obj == self.focus:
+                return np.inf
+            # Calculate the location of the focal plane
+            plane = 1/(1/self.focus - 1/obj)
+            # Find the position in accelerator coordinates
+            return plane + self.z
+        else:
+            if obj == self.req_focus:
+                return np.inf
+            plane = 1/(1/self.req_focus - 1/obj)
+            return plane + self.z
 
     def _do_move(self, state):
         if state.name == 'IN':
@@ -166,7 +189,7 @@ class LensConnect:
             return 0.0
         return 1/np.sum(np.reciprocal([float(l.radius) for l in self.lenses]))
 
-    def image(self, z_obj):
+    def image(self, z_obj, requested=False):
         """
         Method recursively calculates the z location of the image of a system
         of lenses and returns it in meters (m)
@@ -177,6 +200,10 @@ class LensConnect:
             Location of the object along the beam pipline from a designated
             point of origin in meters (m)
 
+        requested
+            Bool to select requested or current beam energy (and as a result
+            requested or current lens focus)
+
         Returns
         -------
         float
@@ -186,7 +213,7 @@ class LensConnect:
         image = z_obj
         # Determine the final output by looping through lenses
         for lens in self.lenses:
-            image = lens.image_from_obj(image)
+            image = lens.image_from_obj(image, requested=requested)
         return image
 
     @property

--- a/transfocate/tests/test_lens.py
+++ b/transfocate/tests/test_lens.py
@@ -11,6 +11,7 @@ import numpy as np
 # Module #
 ##########
 
+
 def test_lens_properties(lens):
     assert np.isclose(500.0, lens.radius, atol=0.1)
     assert np.isclose(100.0, lens.z,      atol=0.1)

--- a/transfocate/tests/test_transfocate.py
+++ b/transfocate/tests/test_transfocate.py
@@ -91,10 +91,13 @@ def test_constant_energy_no_change(transfocator):
     def nothing(transfocator):
         pass
 
-    wrapped_func = constant_energy(nothing)
-    wrapped_func(transfocator, 'req_energy', 0.1)
-    wrapped_func(transfocator, 'beam_energy', 0.1)
-
+#    wrapped_func = constant_energy(nothing)
+#    wrapped_func(transfocator, 'req_energy', 0.1)
+#    wrapped_func(transfocator, 'beam_energy', 0.1)
+    wrapped_func_req = constant_energy(nothing, transfocator, 'req_energy', 0.1)
+    wrapped_func_req()
+    wrapped_func_beam = constant_energy(nothing, transfocator, 'beam_energy', 0.1)
+    wrapped_func_beam()
 
 def test_constant_energy_with_change(transfocator):
     # tests constant_energy when there is a signficant change to the req_energy
@@ -109,14 +112,17 @@ def test_constant_energy_with_change(transfocator):
         transfocator.beam_energy.put(new_energy)
 
     with pytest.raises(TransfocatorEnergyInterrupt):
-        wrapped_func = constant_energy(change_energy)
-        wrapped_func(transfocator, 'req_energy', 0.1, new_energy)
-        wrapped_func(transfocator, 'beam_energy', 0.1, new_energy)
-
+#        wrapped_func = constant_energy(change_energy)
+#        wrapped_func(transfocator, 'req_energy', 0.1, new_energy)
+#        wrapped_func(transfocator, 'beam_energy', 0.1, new_energy)
+        wrapped_func_req = constant_energy(change_energy, transfocator, 'req_energy', 0.1)
+        wrapped_func_req(new_energy)
+        wrapped_func_beam = constant_energy(change_energy, transfocator, 'beam_energy', 0.1)
+        wrapped_func_beam(new_energy)
 
 def test_constant_energy_bad_input(transfocator):
     def nothing(transfocator):
         pass
     with pytest.raises(AttributeError):
-        wrapped_func = constant_energy(nothing)
-        wrapped_func(transfocator, 'bad_input_string', 0.1)
+        wrapped_func = constant_energy(nothing, transfocator, 'bad_input_string', 0.1)
+        wrapped_func()

--- a/transfocate/tests/test_transfocate.py
+++ b/transfocate/tests/test_transfocate.py
@@ -30,17 +30,21 @@ def transfocator():
         lens._sig_z.sim_put(100.0)
         lens._sig_focus.sim_put(1000.0)
         lens._sig_radius.sim_put(100.0)
+        lens._req_focus.sim_put(100.0)
         remove(lens)
     for lens, z in zip(trans.tfs_lenses,
                        np.linspace(250, 260, len(trans.tfs_lenses))):
         lens._sig_z.sim_put(z)
         lens._sig_focus.sim_put(1000.0)
         lens._sig_radius.sim_put(100.0)
+        lens._req_focus.sim_put(100.0)
         remove(lens)
     # Give two reasonable values so we can test calculations
     trans.prefocus_bot._sig_focus.sim_put(50.0)
+    trans.prefocus_bot._req_focus.sim_put(50.0)
     trans.tfs_02._sig_z.sim_put(275.)
     trans.tfs_02._sig_focus.sim_put(25.)
+    trans.tfs_02._req_focus.sim_put(25.)
     # Use a nominal sample position
     trans.nominal_sample = 300.0
     # Set a reasonable limit
@@ -59,6 +63,7 @@ def test_transfocator_current_focus(transfocator):
 
 def test_transfocator_find_best_combo(transfocator):
     # A solution with a prefocus
+    transfocator.beam_energy.put(9536.5)
     combo = transfocator.find_best_combo(312.5)
     assert combo.nlens == 2
     assert np.isclose(312.5, combo.image(0.0), atol=0.1)
@@ -72,6 +77,7 @@ def test_transfocator_find_best_combo(transfocator):
 def test_transfocator_focus_at(transfocator):
     # test with tfs[0] and xrt[0]
     # Insert Transfocator lenses so we can test that they are properly removed
+    transfocator.beam_energy.put(9536.5)
     for lens in transfocator.tfs_lenses:
         insert(lens)
     transfocator.focus_at(value=312.5, wait=False)
@@ -91,13 +97,11 @@ def test_constant_energy_no_change(transfocator):
     def nothing(transfocator):
         pass
 
-#    wrapped_func = constant_energy(nothing)
-#    wrapped_func(transfocator, 'req_energy', 0.1)
-#    wrapped_func(transfocator, 'beam_energy', 0.1)
     wrapped_func_req = constant_energy(nothing, transfocator, 'req_energy', 0.1)
-    wrapped_func_req()
+    wrapped_func_req(transfocator)
     wrapped_func_beam = constant_energy(nothing, transfocator, 'beam_energy', 0.1)
-    wrapped_func_beam()
+    wrapped_func_beam(transfocator)
+
 
 def test_constant_energy_with_change(transfocator):
     # tests constant_energy when there is a signficant change to the req_energy
@@ -112,13 +116,11 @@ def test_constant_energy_with_change(transfocator):
         transfocator.beam_energy.put(new_energy)
 
     with pytest.raises(TransfocatorEnergyInterrupt):
-#        wrapped_func = constant_energy(change_energy)
-#        wrapped_func(transfocator, 'req_energy', 0.1, new_energy)
-#        wrapped_func(transfocator, 'beam_energy', 0.1, new_energy)
         wrapped_func_req = constant_energy(change_energy, transfocator, 'req_energy', 0.1)
-        wrapped_func_req(new_energy)
+        wrapped_func_req(transfocator, new_energy)
         wrapped_func_beam = constant_energy(change_energy, transfocator, 'beam_energy', 0.1)
-        wrapped_func_beam(new_energy)
+        wrapped_func_beam(transfocator, new_energy)
+
 
 def test_constant_energy_bad_input(transfocator):
     def nothing(transfocator):
@@ -126,3 +128,15 @@ def test_constant_energy_bad_input(transfocator):
     with pytest.raises(AttributeError):
         wrapped_func = constant_energy(nothing, transfocator, 'bad_input_string', 0.1)
         wrapped_func()
+
+
+def test_transfocator_find_best_combo_req(transfocator):
+    # A solution with a prefocus
+    combo = transfocator.find_best_combo(312.5, energy=9536.0)
+    assert combo.nlens == 2
+    assert np.isclose(312.5, combo.image(0.0), atol=0.1)
+    # A solution where there are no valid prefocus
+    transfocator.xrt_limit.sim_put(1500.)
+    combo = transfocator.find_best_combo(target=302.5, energy=9536.0)
+    assert combo.nlens == 1
+    assert np.isclose(302.5, combo.image(0.0), atol=0.1)

--- a/transfocate/transfocator.py
+++ b/transfocate/transfocator.py
@@ -196,7 +196,7 @@ class TransfocatorEnergyInterrupt(Exception):
     pass
 
 
-def constant_energy(func):
+def constant_energy(func, transfocator_obj, energy_type, tolerance):
     """
     Ensures that requested energy does not change during calculation
 
@@ -212,7 +212,7 @@ def constant_energy(func):
         calculation and still assumed constant
     """
     @wraps(func)
-    def with_constant_energy(transfocator_obj, energy_type, tolerance, *args, **kwargs):
+    def with_constant_energy(*args, **kwargs):
         try:
             energy_signal = getattr(transfocator_obj, energy_type)
         except Exception as e:


### PR DESCRIPTION
Two major changes on this branch:
First: cleaned up function wrapper `constant_energy(func, transfocator_obj, energy_type, tolerance)` to now take in more arguments that just a function `func`. The returned function `with_constant_energy(*args, **kwargs)` now takes in arguments as it would "unwrapped" while the arguments necessary for wrapping are passed to `constant_energy`. Updated testing functions to reflect this.

Second: 
Made changes necessary to input a requested energy to `Transfocator.find_best_combo`. Added `Lens.req_focus(self)` to convert the epics signal for requested focal length into a float. Updated `Lens.image_from_obj(self, z_obj, requested=False)` with the `requested` bool parameter to select whether using requested or actual focus. Updated `LensConnect.image(self, z_obj, requested=False)` with the `requested` bool parameter that is passed to `Lens.image_from_obj`. Updated `Calculator.find_solution(self, target, n=4, z_obj=0.0, include_prefocus=True, requested=False)` with the `requested` bool parameter that is passed to `LensConnect.image`. Finally, updated `Transfocator.find_best_combo(self, target=None, show=True, energy=None, abs_tol=0.1, **kwargs)` with both the `energy` variable that sets the requested bool when given an actual value and the `abs_tol` variable to set how much the energy (actual beam or requested) may change during a calculation without resulting in an error. Also applied the `constant_energy` wrapper to `Calculator.find_solution` for both the requested and current beam energy cases.