### PR TITLE
MNT: Update for ophyd=1.5.0, pcdsdevices=2.6.0, and pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - conda install conda-build anaconda-client
   - conda update -q conda
   - conda config --append channels pcds-tag
-  - conda config --append channels conda-forge
+  - conda config --add channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
   - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,9 +17,9 @@ requirements:
 
   run:
     - python {{PY_VER}}*,>=3.6
-    - ophyd >=1.2.0
+    - ophyd >=1.5.0
     - numpy
-    - pcdsdevices >=0.5.0
+    - pcdsdevices >=2.6.0
 
 test:
   imports:

--- a/transfocate/lens.py
+++ b/transfocate/lens.py
@@ -61,7 +61,7 @@ class Lens(InOutPVStatePositioner):
         float
             Returns the radius of the lens
         """
-        return self._sig_radius.value
+        return self._sig_radius.get()
 
     @property
     def z(self):
@@ -73,7 +73,7 @@ class Lens(InOutPVStatePositioner):
         float
             Returns the z position of the lens in meters along the beamline
         """
-        return self._sig_z.value
+        return self._sig_z.get()
 
     @property
     def focus(self):
@@ -85,7 +85,7 @@ class Lens(InOutPVStatePositioner):
         float
             Returns the focal length of the lens in meters
         """
-        return self._sig_focus.value
+        return self._sig_focus.get()
 
     def image_from_obj(self, z_obj):
         """

--- a/transfocate/tests/__init__.py
+++ b/transfocate/tests/__init__.py
@@ -3,6 +3,6 @@ __all__ = ['test_transfocate']
 from . import test_transfocate
 
 # Create a Transfocator with a few inserted lenses
-transfocator = test_transfocate.transfocator()
+transfocator = test_transfocate.make_fake_transfocator()
 test_transfocate.insert(transfocator.prefocus_mid)
 test_transfocate.insert(transfocator.tfs_02)

--- a/transfocate/tests/test_transfocate.py
+++ b/transfocate/tests/test_transfocate.py
@@ -74,14 +74,19 @@ def test_transfocator_find_best_combo(transfocator):
 
 def test_transfocator_focus_at(transfocator):
     # test with tfs[0] and xrt[0]
-    # Insert Transfocator lenses so we can test that they are properly removed
+    # Set Transfocator lenses to the wrong state for this focus
     for lens in transfocator.tfs_lenses:
-        insert(lens)
+        if lens == transfocator.tfs_02:
+            remove(lens)
+        else:
+            insert(lens)
+    # Make sure they all get moved correctly
     transfocator.focus_at(value=312.5, wait=False)
     assert transfocator.prefocus_bot._insert.get() == 1
-    assert transfocator.tfs_02._insert.get() == 1
     for lens in transfocator.tfs_lenses:
-        if lens != transfocator.tfs_02:
+        if lens == transfocator.tfs_02:
+            assert lens._insert.get() == 1
+        else:
             assert lens._remove.get() == 1
 
 

--- a/transfocate/tests/test_transfocate.py
+++ b/transfocate/tests/test_transfocate.py
@@ -22,6 +22,9 @@ def remove(lens):
 
 @pytest.fixture(scope='function')
 def transfocator():
+    return make_fake_transfocator()
+
+def make_fake_transfocator():
     FakeTransfocator = make_fake_device(Transfocator)
     # Create our base transfocator
     trans = FakeTransfocator("TST:LENS", name='Transfocator')


### PR DESCRIPTION
The one oddball patch here is that `pcdsdevices` no longer does anything on `insert()` if we are already `inserted` or on `remove()` if we're already removed. So one test was assuming the old behavior and had to be changed.

`pytest`'s warning for calling a fixture is now an exception. So I'm finally adjusting that.

The rest is standard `ophyd=1.5.0` and general maintenance updates.