### PR TITLE
REF/FIX: remove evil matplotlib.use-on-import

### DIFF
--- a/transfocate/table/ioc.py
+++ b/transfocate/table/ioc.py
@@ -1,13 +1,9 @@
 """Generate IOC header files (in C) for the spreadsheet table."""
 import sys
 
-import matplotlib
 import numpy as np
 import pandas as pd
 
-matplotlib.use("Agg")  # noqa
-
-import matplotlib.pyplot as plt  # noqa
 
 from .info import data as spreadsheet_data
 
@@ -134,6 +130,10 @@ def main():
     """
     code = generate_header()
     print(code)
+
+    import matplotlib  # noqa
+    matplotlib.use("Agg")  # noqa
+    import matplotlib.pyplot as plt  # noqa
 
     _, axes = plt.subplots(
         ncols=2, nrows=2, constrained_layout=True, dpi=120, figsize=(11, 8)

--- a/transfocate/table/plc_table.py
+++ b/transfocate/table/plc_table.py
@@ -1,13 +1,8 @@
 """Create Beckhoff TwinCAT PLC source code for the spreadsheet."""
 import sys
 
-import matplotlib
 import numpy as np
 import pandas as pd
-
-matplotlib.use("Agg")  # noqa
-
-import matplotlib.pyplot as plt  # noqa
 
 from .info import data as spreadsheet_data
 
@@ -116,6 +111,10 @@ def main():
     """
     code = generate_source()
     print(code)
+
+    import matplotlib  # noqa
+    matplotlib.use("Agg")  # noqa
+    import matplotlib.pyplot as plt  # noqa
 
     _, axes = plt.subplots(
         ncols=2, nrows=2, constrained_layout=True, dpi=120, figsize=(11, 8)


### PR DESCRIPTION
Convenient imports + convenient agg-setting for CLI tools = disaster for hutch-python