### PR TITLE
MAINT: remove slow top-level import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ env:
 
 jobs:
   allow_failures:
-    - name: "Python 3.6 - PIP"
-    - name: "Python Linter"
+    - name: "Pre-commit Checks"
 
 import:
   # This import enables a set of standard python jobs including:

--- a/transfocate/__init__.py
+++ b/transfocate/__init__.py
@@ -1,9 +1,8 @@
-__all__ = ['Lens', 'LensConnect', 'Calculator', 'Transfocator', 'table']
+__all__ = ['Lens', 'LensConnect', 'Calculator', 'Transfocator']
 
 from .lens import Lens, LensConnect
 from .calculator import Calculator
 from .transfocator import Transfocator
-from . import table
 
 from ._version import get_versions
 __version__ = get_versions()['version']


### PR DESCRIPTION
Quick change following from #55. This closes #55.
I think this is worth merging if the tests pass.

Here's the new benchmark after the change, sorted by import time:
```
+--------------------------+-----------------------+------------+-----------------------+-----------------------+------------------------+
|           name           |        avg_time       | iterations |        tot_time       |        max_time       |      import_time       |
+--------------------------+-----------------------+------------+-----------------------+-----------------------+------------------------+
|        mr1l3_homs        |  0.004080776125192642 |     1      |  0.004080776125192642 |  0.004080776125192642 |   1.0933156684041023   |
|          al1k2           |  0.002440035343170166 |     1      |  0.002440035343170166 |  0.002440035343170166 |   0.3839171677827835   |
|         mfx_tfs          |  0.02548867091536522  |     1      |  0.02548867091536522  |  0.02548867091536522  |  0.15631813555955887   |
|          st1k4           | 0.0018379352986812592 |     1      | 0.0018379352986812592 | 0.0018379352986812592 |  0.027277540415525436  |
|        lm1k4_qadc        |  0.004456564784049988 |     1      |  0.004456564784049988 |  0.004456564784049988 |  0.027051206678152084  |
|         tmo_cvmi         |  0.00167885422706604  |     1      |  0.00167885422706604  |  0.00167885422706604  |  0.013568688184022903  |
|          rtdsk0          | 0.0017196573317050934 |     1      | 0.0017196573317050934 | 0.0017196573317050934 | 0.0046474263072013855  |
|          em1l0           | 0.0017943046987056732 |     1      | 0.0017943046987056732 | 0.0017943046987056732 |  0.003668617457151413  |
|         tmo_mrco         | 0.0016117729246616364 |     1      | 0.0016117729246616364 | 0.0016117729246616364 | 0.0036447495222091675  |
```
And here's the before and after import timers:
```
(pcds-5.4.1)zlentz@psbuild-rhel7-01:~/github/transfocate(master -)$ python -m pcdsutils.import_timer transfocate
+----------------------------------------+-----------+-----------------+
|              root_module               | self_time | cumulative_time |
+----------------------------------------+-----------+-----------------+
|              pcdsdevices               |  0.998159 |     1.947297    |
|              transfocate               |  0.965988 |     7.028316    |
|             pkg_resources              |  0.883721 |     0.899879    |
|                 ophyd                  |  0.691266 |     1.920908    |
|                 pandas                 |  0.599808 |     0.754515    |
|                openpyxl                |  0.409417 |     0.508336    |
|                networkx                |  0.305008 |     0.316594    |
|                 numpy                  |  0.190994 |     0.230065    |
|               setuptools               |  0.162748 |     0.175498    |
|               reportlab                |  0.160138 |     0.15782     |
|               pcdsutils                |  0.134482 |     0.139769    |

(pcds-5.4.1)zlentz@psbuild-rhel7-01:~/github/transfocate(maint_imports +)$ python -m pcdsutils.import_timer transfocate
+----------------------------+-----------+-----------------+
|        root_module         | self_time | cumulative_time |
+----------------------------+-----------+-----------------+
|       pkg_resources        |  1.008252 |     1.025676    |
|        pcdsdevices         |  0.935654 |     1.772142    |
|           ophyd            |  0.771135 |     2.404881    |
|          networkx          |  0.509518 |     0.538365    |
|           numpy            |  0.211389 |     0.267241    |
|          pcdscalc          |  0.133752 |     0.129645    |
|         pcdsutils          |  0.129356 |     0.131189    |
|         setuptools         |  0.124187 |     0.15047     |
|        transfocate         |  0.109776 |     5.047012    |
|           jinja2           |  0.091878 |     0.095074    |
|           toolz            |  0.070151 |     0.070146    |
|           epics            |  0.058995 |     1.10476     |
```
