### PR TITLE
BLD: use bluesky-base instead of bluesky for conda build

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   - pip
   run:
   - python >=3.9
-  - bluesky
+  - bluesky-base
   - databroker
   - matplotlib-base
   - numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,5 @@ file = [ "requirements.txt",]
 [tool.setuptools.dynamic.optional-dependencies.test]
 file = "dev-requirements.txt"
 
-[tool.setuptools.dynamic.optional-dependencies.docs]
+[tool.setuptools.dynamic.optional-dependencies.doc]
 file = "docs-requirements.txt"


### PR DESCRIPTION
Make sure matplotlib qt dependencies do not get installed here.  We'll see if the CI bears this out